### PR TITLE
chore: upgrade Astro to v6.1.6 and confirm Keystatic removal

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/node": "^10.0.4",
         "@iconify-json/ion": "^1.2.7",
         "@iconify-json/mdi": "^1.2.3",
-        "astro": "^6.1.4",
+        "astro": "^6.1.6",
         "astro-icon": "^1.1.5",
         "markdown-it": "^14.1.1",
         "minisearch": "^7.2.0",
@@ -2357,9 +2357,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.4.tgz",
-      "integrity": "sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.6.tgz",
+      "integrity": "sha512-pRsz+kYriwCV/AUcY/I9OVKtVHuYFs2DtCszAxprXded/kTE53nMwxfnK0Nf6FPfaX9vcUiLnigcSIhuFoKntA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
@@ -2378,7 +2378,6 @@
         "cookie": "^1.1.1",
         "devalue": "^5.6.3",
         "diff": "^8.0.3",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.27.3",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@astrojs/node": "^10.0.4",
     "@iconify-json/ion": "^1.2.7",
     "@iconify-json/mdi": "^1.2.3",
-    "astro": "^6.1.4",
+    "astro": "^6.1.6",
     "astro-icon": "^1.1.5",
     "markdown-it": "^14.1.1",
     "minisearch": "^7.2.0",


### PR DESCRIPTION
## Summary

- Upgraded Astro from v6.1.4 to v6.1.6 (latest) using the official `@astrojs/upgrade` tool
- Confirmed Keystatic is fully stripped — no packages, no config, no routes remain
- All official Astro integrations were already on their latest versions

## Details

The Keystatic CMS had already been removed from this branch prior to this session (no `@keystatic/*` packages in `package.json`, no `keystatic.config.ts`, no Keystatic routes). The only remaining mention is [`src/content/posts/posting-from-keystatic.md`](website/src/content/posts/posting-from-keystatic.md), which is a draft test post left as-is since it's just content.

The Astro upgrade is a patch-level bump (6.1.4 → 6.1.6). Build was verified clean after the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)